### PR TITLE
Certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,13 @@ MONGO_PASSWORD=
 AUTHENTICATOR_SECRET=...your long string...
 
 # portal
-PORTAL_PORT=80
+# see docker-compose-dcc.yml
+PORTAL_PORT=443
+# full path volume mount point, mounted in container as '/certs'
+CERT_DIR_PATH=... full path name to directory containing .cer & .key
+# paths to cert & key relative to container, see services/dcc-portal/dcc-portal-ui/tasks/start.js
+KEY_PATH=/certs/full-name.key
+CERT_PATH=/certs/full-name.cer
 
 ```
 

--- a/docker-compose-dcc.yml
+++ b/docker-compose-dcc.yml
@@ -8,10 +8,14 @@ services:
     build:
       context: services/dcc-portal
     ports:
-      - "${PORTAL_PORT}:9000"
+      - "${PORTAL_PORT}:${PORTAL_PORT}"
     links:
       - api
+    volumes:
+      - "${CERT_DIR_PATH}:/certs/"
     environment:
-      - PORT=9000
+      - PORT=${PORTAL_PORT}
       - API_SOURCE=${API_URL}
+      - KEY_PATH=${KEY_PATH}
+      - CERT_PATH=${CERT_PATH}
       - NODE_ENV=development

--- a/docs/images/websequencediagrams.com.txt
+++ b/docs/images/websequencediagrams.com.txt
@@ -1,0 +1,14 @@
+# see https://www.websequencediagrams.com/
+Client->Keystone: credentials[user,pass]
+Keystone->Client: token
+Client->AnyService: /any/url header:[token,...]
+AnyService->Keystone: validate(token)
+Keystone->AnyService: project_roles[...]
+alt token-invalid-or-no-role-onproject
+    AnyService->Client:unauthorized
+    note right of Client: 401 returned
+else valid
+    AnyService->AnyService:any-compute
+    AnyService->Client:response
+    note right of Client: service data
+end

--- a/services/keystone/Dockerfile
+++ b/services/keystone/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER walsbr "walsbr@ohsu.edu"
 
 # see https://wiki.opnfv.org/display/functest/OpenStack+python+clients
 ENV VERSION=10.0.0
-ENV CLIENT_VERSION=3.2.0
+ENV CLIENT_VERSION=3.7.0
 
 # update catalog, install keystone dependencies, ldap dependencies,
 # dev dependencies & the clean up


### PR DESCRIPTION
This PR implements 1 new feature:
* add support for auto-configuration of branding and certificates [EUL-36,25]
* paired with dcc-portal PR https://github.com/ohsu-computational-biology/dcc-portal/pull/15

Other:
* maintenance of docs/images
* openstack client version increment due to new release

Implementation details:
* .env file has new variables [CERT_DIR_PATH, KEY_PATH, CERT_PATH]
* existing env variable PORTAL_PORT should be set to 443
* see *.cer and *.key files recently delivered by ACC
